### PR TITLE
MAPREDUCE-7357. Clean shared state pollution to avoid flaky tests in class TestAppCon…

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAppController.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/webapp/TestAppController.java
@@ -319,6 +319,7 @@ public class TestAppController {
     appController.attempts();
 
     assertEquals(AttemptsPage.class, appController.getClazz());
+    appController.getProperty().remove(AMParams.ATTEMPT_STATE);
   }
 
 }


### PR DESCRIPTION
Link to issue: [https://issues.apache.org/jira/browse/MAPREDUCE-7357](https://issues.apache.org/jira/browse/MAPREDUCE-7357)
## What is the purpose of this change
This PR is to fix a non-idempotent test `org.apache.hadoop.mapreduce.v2.app.webapp.TestAppController.testAttempt`
## Why the test failed
The root cause for the failure is that this test does not remove the value of key `AMParams.ATTEMPT_STATE`, which pollutes the shared state. It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state polluted by this test.
## Reproduce test failure
Run the test twice in the same JVM.
## Expected result
The test should run successfully without any failures.
## Actual result
Failure from test run:
```
[ERROR] TestAppController.testAttempts:315 expected:<[Bad request: missing attempt-state.]> but was:<[State MAP attempts in job_01_01]>
```
## Fix 
 Remove the `AMParams.ATTEMPT_STATE` key-value pair (`appController.getProperty().remove(AMParams.ATTEMPT_STATE)`).
