### PR TITLE
MAPREDUCE-7358. Clean shared state pollution to avoid flaky test testMR

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/NotificationTestCase.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/NotificationTestCase.java
@@ -206,6 +206,7 @@ public abstract class NotificationTestCase extends HadoopTestCase {
     }
     assertEquals(6, NotificationServlet.counter);
     assertEquals(0, NotificationServlet.failureCounter);
+    NotificationServlet.counter = 0;
   }
 
   private String launchWordCount(JobConf conf,


### PR DESCRIPTION
This PR is similar to merged #2499, but for a different test.
Link to issue: [https://issues.apache.org/jira/browse/MAPREDUCE-7358](https://issues.apache.org/jira/browse/MAPREDUCE-7358)
## What is the purpose of this change
This PR is to fix a non-idempotent test `org.apache.hadoop.mapred.TestClusterMRNotification.testMR`.

## Why the test failed
The root cause for the failure is that this test does not clean `NotificationServlet.counter` at the end, which pollutes the shared state. It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state polluted by this test.

## Reproduce test failure
Run the test twice in the same JVM.

## Expected result
The test should run successfully without any failures.

## Actual result
Failure from test run:
`NotificationTestCase.testMR:174 expected:<2> but was:<8>`
# Fix
Clear the value of `NotificationServlet.counter` at the end of the test.

