### PR TITLE
MAPREDUCE-7359. Clean shared state pollution to avoid flaky tests testCombiner

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestOldCombinerGrouping.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestOldCombinerGrouping.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.mapred;
 
 import org.junit.Assert;
+import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.RawComparator;
@@ -119,7 +120,8 @@ public class TestOldCombinerGrouping {
 
   @Test
   public void testCombiner() throws Exception {
-    if (!new File(TEST_ROOT_DIR).mkdirs()) {
+    File setup = new File(TEST_ROOT_DIR);
+    if (!setup.mkdirs()) {
       throw new RuntimeException("Could not create test dir: " + TEST_ROOT_DIR);
     }
     File in = new File(TEST_ROOT_DIR, "input");
@@ -187,6 +189,7 @@ public class TestOldCombinerGrouping {
     } else {
       Assert.fail("Job failed");
     }
+    FileUtil.fullyDelete(setup);
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestNewCombinerGrouping.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestNewCombinerGrouping.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.mapreduce;
 
 import org.junit.Assert;
+import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.RawComparator;
@@ -105,7 +106,8 @@ public class TestNewCombinerGrouping {
 
   @Test
   public void testCombiner() throws Exception {
-    if (!new File(TEST_ROOT_DIR).mkdirs()) {
+    File setup = new File(TEST_ROOT_DIR);
+    if (!setup.mkdirs()) {
       throw new RuntimeException("Could not create test dir: " + TEST_ROOT_DIR);
     }
     File in = new File(TEST_ROOT_DIR, "input");
@@ -174,6 +176,7 @@ public class TestNewCombinerGrouping {
     } else {
       Assert.fail("Job failed");
     }
+    FileUtil.fullyDelete(setup);
   }
 
 }


### PR DESCRIPTION
Link to issue: [https://issues.apache.org/jira/browse/MAPREDUCE-7359](https://issues.apache.org/jira/browse/MAPREDUCE-7359)
## What is the purpose of this change
This PR is to fix 2 non-idempotent flaky tests: 
```
org.apache.hadoop.mapred.TestOldCombinerGrouping.testCombiner
org.apache.hadoop.mapreduce.TestNewCombinerGrouping.testCombiner
```

## Why the tests failed
For test `xxx.testcombiner`, it writes to the directory `TEST_ROOT_DIR` whose path is determined by UUID. When running this test twice, the `TEST_ROOT_DIR` created by the first running already exists, so the second running cannot create the directory with the same name, which can lead to a `RuntimeException`. This will pollute the shared state. It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state polluted by this test.

## Reproduce test failure
Run the tests twice in the same JVM. 

## Expected result
The tests should run successfully without any failure when multiple tests that use this state are run in the same JVM.

## Actual result
Failure:
```
java.lang.RuntimeException: Could not create test dir: /home/...
```

## Fix
Fully delete the directory created for this test when it ends.