### PR TITLE
MAPREDUCE-7360. Clean shared state pollution to avoid flaky tests in class TestMRAppM…

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRAppMaster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/TestMRAppMaster.java
@@ -504,6 +504,7 @@ public class TestMRAppMaster {
   @Test
   public void testMRAppMasterShutDownJob() throws Exception,
       InterruptedException {
+    ExitUtil.resetFirstExitException();
     String applicationAttemptIdStr = "appattempt_1317529182569_0004_000002";
     String containerIdStr = "container_1317529182569_0004_000002_1";
     String userName = "TestAppMasterUser";


### PR DESCRIPTION
Link to issue: [https://issues.apache.org/jira/browse/MAPREDUCE-7360](https://issues.apache.org/jira/browse/MAPREDUCE-7360)
## What is the purpose of this change
This PR is to clean shared state pollution between tests:
```
Test1: org.apache.hadoop.mapreduce.v2.app.TestJobEndNotifier.testNotificationOnLastRetryShutdownWithRuntimeException
Test2: org.apache.hadoop.mapreduce.v2.app.TestMRAppMaster.testMRAppMasterShutDownJob
```
- Test1 can pollute the shared state with Test2, which can lead Test2 to fail after running Test1.
- It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state polluted by this test.

## Reproduce test failure
First run Test1, then run Test2 in the same JVM

## Expected result
The tests should run successfully when multiple tests that use this state are run in the same JVM.

## Actual result
Run Test1 and Test2, Test2 fails:
```
[ERROR]   TestMRAppMaster.testMRAppMasterShutDownJob:530 Expected shutDownJob to exit with status code of 0. expected:<0> but was:<1>
```

## Fix
Reset FirstExitException at the start of Test2 to clean the pollution from Test1.