### PR TITLE
Clean the snapshot to avoid flaky tests.

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/fs/http/server/TestHttpFSServer.java
@@ -1362,6 +1362,9 @@ public class TestHttpFSServer extends HFSTestCase {
     result = getStatus("/tmp/tmp-snap-test/.snapshot",
         "LISTSTATUS");
     Assert.assertTrue(result.contains("snap-with-name"));
+    snapshotTestPreconditions("DELETE",
+        "DELETESNAPSHOT",
+        "snapshotname=snap-with-name").getResponseCode();
   }
 
   @Test
@@ -1411,6 +1414,9 @@ public class TestHttpFSServer extends HFSTestCase {
     Assert.assertTrue(result.contains("snap-renamed"));
     //There should be no snapshot named snap-to-rename now
     Assert.assertFalse(result.contains("snap-to-rename"));
+    snapshotTestPreconditions("DELETE",
+        "DELETESNAPSHOT",
+        "snapshotname=snap-renamed").getResponseCode();
   }
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
1. This PR is to fix 2 non-idempotent tests:
- `org.apache.hadoop.fs.http.server.TestHttpFSServer.testCreateSnapshot`
- `org.apache.hadoop.fs.http.server.TestHttpFSServer.testRenameSnapshot`
2. Reproduce the test failure
- Run the test twice in the same JVM.
3. Expected result:
- The tests should run successfully when multiple tests that use this state are run in the same JVM.
4. Actual result:
We get the following failure, which indicates internal server errors:
- Failure after `org.apache.hadoop.fs.http.server.TestHttpFSServer.testCreateSnapshot`:
```
[ERROR]   TestHttpFSServer.testCreateSnapshot:1364 expected:<500> but was:<200>
```
```
org.apache.hadoop.hdfs.protocol.SnapshotException: Failed to add snapshot: there is already a snapshot with the same name "snap-with-name".
```
- Failure after `org.apache.hadoop.fs.http.server.TestHttpFSServer.testRenameSnapshot` :
```
[ERROR]   TestHttpFSServer.testCreateSnapshot:1364 expected:<500> but was:<200>
```
```
org.apache.hadoop.hdfs.protocol.SnapshotException: Failed to add snapshot: there is already a snapshot with the same name "snap-to-rename".
```
5. Why the tests fail:
- Each time the tests run, a new snapshot will be created with the same name. But this snapshot was already created and connected after the first run. So because the URL was built and the HTTP connection was opened already, creating and connecting the same URL again leads to an server error.
- It would be better to create snapshots with different names each time. 

### For code changes:
- Delete the snapshot created for test at the end of tests.

<!--
### How was this patch tested?



-->
- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

