### PR TITLE
Clean up test directory after test class to avoid DiskErrorException

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestMapTask.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/test/java/org/apache/hadoop/mapred/TestMapTask.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.mapreduce.TaskCounter;
 import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.util.Progress;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -46,8 +46,8 @@ public class TestMapTask {
           System.getProperty("java.io.tmpdir", "/tmp")),
       TestMapTask.class.getName());
 
-  @After
-  public void cleanup() throws Exception {
+  @AfterClass
+  public static void cleanup() throws Exception {
     FileUtil.fullyDelete(TEST_ROOT_DIR);
   }
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
    
### How was this patch tested?
-->
### Why we change this
- Changing `After` to `AfterClass` so that future tests added to `TestMapTask` would not fail because the directory is already deleted.
### Description of PR
1. This PR is to fix a non-idempotent test :
- `org.apache.hadoop.mapred.TestMapTask.testShufflePermissions`
2. Reproduce the test failure
- Run the test twice in the same JVM.
3. Expected result
- The test should run successfully.
4. Actual result
- We get the following failure:
`org.apache.hadoop.util.DiskChecker$DiskErrorException: Could not find any valid local directory for output/file.out`
5. Why the test fails
- `TEST_ROOT_DIR` was deleted after the first run, when the test runs the second time, the test directory does not exist.
6. Fix
- Change `After` to `AfterClass`.

### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

