### PR TITLE
Reset mrCluster to null when test ends to avoid flaky tests

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMRJobsWithHistoryService.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMRJobsWithHistoryService.java
@@ -162,6 +162,7 @@ public class TestMRJobsWithHistoryService {
     gjReq.setJobId(jobId);
     JobReport jobReport = historyClient.getJobReport(gjReq).getJobReport();
     verifyJobReport(jobReport, jobId);
+    mrCluster = null;
   }
 
   private void verifyJobReport(JobReport jobReport, JobId jobId) {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
1. This PR is to fix a non-idempotent flaky test:
- `org.apache.hadoop.mapreduce.v2.TestMRJobsWithHistoryService.testJobHistoryData`
2. Reproduce test failure
- Run the test twice in the same JVM.
3. Expected result
- The test should run successfully when multiple tests that use this state (`mrCluster`) are run in the same JVM.
4. Actual result
- We get the following failure
```
testJobHistoryData(org.apache.hadoop.mapreduce.v2.TestMRJobsWithHistoryService)  Time elapsed: 90.043 s  <<< ERROR!
org.junit.runners.model.TestTimedOutException: test timed out after 90000 milliseconds

java.net.ConnectException: Connection refused
```
5. Why the test fails
- Each time a new `mrCluster` should be created for the test run, but the `mrCluster` was set to `stop` when the first run ends. When the test runs for the second time, the stopped `mrCluster` causes a `ConnectionRefused` exception.
6. Fix
- Reset `mrCluster` to `null` (so that `setup` will create a new `mrCluster` for each test run to avoid shared pollution).



### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

